### PR TITLE
Frame Properties _AbsoluteTime and related

### DIFF
--- a/AviSynth/video_output.cpp
+++ b/AviSynth/video_output.cpp
@@ -858,9 +858,12 @@ void avs_set_frame_properties
     env->propSetInt(props, "_DurationNum", duration_num, 0);
     env->propSetInt(props, "_DurationDen", duration_den, 0);
     env->propSetInt(props, "_PTS", av_frame->pts, 0);
-    env->propSetInt(props, "_TimeBaseNum", stream->time_base.num, 0);
-    env->propSetInt(props, "_TimeBaseDen", stream->time_base.den, 0);
-    env->propSetFloat(props, "_AbsoluteTime", (float)av_frame->pts/stream->time_base.den*stream->time_base.num, 0);
+    if (stream!=NULL)
+    {
+        env->propSetInt(props, "_TimeBaseNum", stream->time_base.num, 0);
+        env->propSetInt(props, "_TimeBaseDen", stream->time_base.den, 0);
+        env->propSetFloat(props, "_AbsoluteTime", (float)av_frame->pts/stream->time_base.den*stream->time_base.num, 0);
+    }
     /* Color format
      * The decoded color format may not match with the output. Set proper properties when
      * no YUV->RGB conversion is there. */

--- a/AviSynth/video_output.cpp
+++ b/AviSynth/video_output.cpp
@@ -858,11 +858,16 @@ void avs_set_frame_properties
     env->propSetInt(props, "_DurationNum", duration_num, 0);
     env->propSetInt(props, "_DurationDen", duration_den, 0);
     env->propSetInt(props, "_PTS", av_frame->pts, 0);
+    env->propSetInt(props, "_PktDTS", av_frame->pkt_dts, 0);
     if (stream!=NULL)
     {
         env->propSetInt(props, "_TimeBaseNum", stream->time_base.num, 0);
         env->propSetInt(props, "_TimeBaseDen", stream->time_base.den, 0);
         env->propSetFloat(props, "_AbsoluteTime", (float)av_frame->pts/stream->time_base.den*stream->time_base.num, 0);
+    }
+    else
+    {
+        env->propSetFloat(props, "_AbsoluteTime", (float)av_frame->pkt_dts/duration_den, 0);
     }
     /* Color format
      * The decoded color format may not match with the output. Set proper properties when

--- a/AviSynth/video_output.cpp
+++ b/AviSynth/video_output.cpp
@@ -857,6 +857,10 @@ void avs_set_frame_properties
     /* Sample duration */
     env->propSetInt(props, "_DurationNum", duration_num, 0);
     env->propSetInt(props, "_DurationDen", duration_den, 0);
+    env->propSetInt(props, "_PTS", av_frame->pts, 0);
+    env->propSetInt(props, "_TimeBaseNum", stream->time_base.num, 0);
+    env->propSetInt(props, "_TimeBaseDen", stream->time_base.den, 0);
+    env->propSetFloat(props, "_AbsoluteTime", (float)av_frame->pts/stream->time_base.den*stream->time_base.num, 0);
     /* Color format
      * The decoded color format may not match with the output. Set proper properties when
      * no YUV->RGB conversion is there. */

--- a/VapourSynth/video_output.c
+++ b/VapourSynth/video_output.c
@@ -1018,6 +1018,10 @@ void vs_set_frame_properties
     /* Sample duration */
     vsapi->propSetInt( props, "_DurationNum", duration_num, paReplace );
     vsapi->propSetInt( props, "_DurationDen", duration_den, paReplace );
+    vsapi->propSetInt( props, "_PTS", av_frame->pts, paReplace );
+    vsapi->propSetInt( props, "_TimeBaseNum", stream->time_base.num, paReplace );
+    vsapi->propSetInt( props, "_TimeBaseDen", stream->time_base.den, paReplace );
+    vsapi->propSetFloat( props, "_AbsoluteTime", (float)av_frame->pts/stream->time_base.den*stream->time_base.num, paReplace );
     /* Color format
      * The decoded color format may not match with the output. Set proper properties when
      * no YUV->RGB conversion is there. */

--- a/VapourSynth/video_output.c
+++ b/VapourSynth/video_output.c
@@ -1019,11 +1019,16 @@ void vs_set_frame_properties
     vsapi->propSetInt( props, "_DurationNum", duration_num, paReplace );
     vsapi->propSetInt( props, "_DurationDen", duration_den, paReplace );
     vsapi->propSetInt( props, "_PTS", av_frame->pts, paReplace );
+    vsapi->propSetInt( props, "_PktDTS", av_frame->pkt_dts, paReplace );
     if( stream!=NULL )
     {
         vsapi->propSetInt( props, "_TimeBaseNum", stream->time_base.num, paReplace );
         vsapi->propSetInt( props, "_TimeBaseDen", stream->time_base.den, paReplace );
         vsapi->propSetFloat( props, "_AbsoluteTime", (float)av_frame->pts/stream->time_base.den*stream->time_base.num, paReplace );
+    }
+    else
+    {
+        vsapi->propSetFloat( props, "_AbsoluteTime", (float)av_frame->pkt_dts/duration_den, paReplace );
     }
     /* Color format
      * The decoded color format may not match with the output. Set proper properties when

--- a/VapourSynth/video_output.c
+++ b/VapourSynth/video_output.c
@@ -1019,9 +1019,12 @@ void vs_set_frame_properties
     vsapi->propSetInt( props, "_DurationNum", duration_num, paReplace );
     vsapi->propSetInt( props, "_DurationDen", duration_den, paReplace );
     vsapi->propSetInt( props, "_PTS", av_frame->pts, paReplace );
-    vsapi->propSetInt( props, "_TimeBaseNum", stream->time_base.num, paReplace );
-    vsapi->propSetInt( props, "_TimeBaseDen", stream->time_base.den, paReplace );
-    vsapi->propSetFloat( props, "_AbsoluteTime", (float)av_frame->pts/stream->time_base.den*stream->time_base.num, paReplace );
+    if( stream!=NULL )
+    {
+        vsapi->propSetInt( props, "_TimeBaseNum", stream->time_base.num, paReplace );
+        vsapi->propSetInt( props, "_TimeBaseDen", stream->time_base.den, paReplace );
+        vsapi->propSetFloat( props, "_AbsoluteTime", (float)av_frame->pts/stream->time_base.den*stream->time_base.num, paReplace );
+    }
     /* Color format
      * The decoded color format may not match with the output. Set proper properties when
      * no YUV->RGB conversion is there. */


### PR DESCRIPTION
I've tested on vapoursynth only because I had trouble building avisynth plugin, and I think it works as expected.
For files like bd m2ts, the time doesn't starts with 0, same as ffms2, but looks like it's ahead by one frame, I have no idea...