### PR TITLE
Fixes for Windows on ARM

### DIFF
--- a/AviSynth/meson.build
+++ b/AviSynth/meson.build
@@ -39,8 +39,6 @@ sources = [
   '../common/lwlibav_video.c',
   '../common/lwlibav_video.h',
   '../common/lwlibav_video_internal.h',
-  '../common/lwsimd.c',
-  '../common/lwsimd.h',
   '../common/osdep.c',
   '../common/osdep.h',
   '../common/progress.h',

--- a/common/libavsmash.c
+++ b/common/libavsmash.c
@@ -44,7 +44,7 @@ extern "C"
 #include "decode.h"
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #include "osdep.h"
 #endif // _WIN32
 

--- a/common/lwlibav_dec.h
+++ b/common/lwlibav_dec.h
@@ -21,7 +21,7 @@
 /* This file is available under an ISC license. */
 
 #ifdef _WIN32
-#include <Windows.h>
+#include <windows.h>
 #include "osdep.h"
 #endif // _WIN32
 


### PR DESCRIPTION
Case sensitivity and a couple of source files that seem like maybe they shouldn't be in the file list for AviSynth, as the only part of the project that appears to use `lwsimd.{c,h}` is AviUtl.

Technically, the lwsimd commit should also fix compiling the plugin on any OS running on non-x86(-64) architectures.