### PR TITLE
Unroll sscanf into strncmp and strtol

### DIFF
--- a/common/lwindex.c
+++ b/common/lwindex.c
@@ -3079,7 +3079,7 @@ static int parse_index
         int64_t pos;
         int64_t pts;
         int64_t dts;
-        if( sscanf_unrolled1( buf, // "Index=%d,POS=%" SCNd64 ",PTS=%" SCNd64 ",DTS=%" SCNd64 ",EDI=%d",
+        if( sscanf_unrolled_main_index( buf, // "Index=%d,POS=%" SCNd64 ",PTS=%" SCNd64 ",DTS=%" SCNd64 ",EDI=%d",
                     &stream_index, &pos, &pts, &dts, &extradata_index ) != 5 )
             goto fail_parsing;
         if( !fgets( buf, sizeof(buf), index ) )
@@ -3111,7 +3111,7 @@ static int parse_index
                 int   poc;
                 int   repeat_pict;
                 int   field_info;
-                if( sscanf_unrolled2( buf, // "Key=%d,Pic=%d,POC=%d,Repeat=%d,Field=%d",
+                if( sscanf_unrolled_video_index( buf, // "Key=%d,Pic=%d,POC=%d,Repeat=%d,Field=%d",
                             &key, &pict_type, &poc, &repeat_pict, &field_info ) != 5 )
                     goto fail_parsing;
                 if( vdhp->codec_id == AV_CODEC_ID_NONE )
@@ -3193,7 +3193,7 @@ static int parse_index
                 char    *sample_fmt      = stream_info[stream_index].fmt;
                 int      bits_per_sample = stream_info[stream_index].bits_per_sample;
                 int      frame_length;
-                if( sscanf_unrolled3( buf, // "Length=%d"
+                if( sscanf_unrolled_audio_index( buf, // "Length=%d",
                             &frame_length ) != 1 )
                     goto fail_parsing;
                 if( adhp->codec_id == AV_CODEC_ID_NONE )

--- a/common/lwindex.c
+++ b/common/lwindex.c
@@ -61,6 +61,8 @@ extern "C"
 #include <windows.h>
 #endif
 
+#include "lwindex_sscanf_unrolled.h"
+
 typedef struct
 {
     lwlibav_extradata_handler_t exh;
@@ -3077,7 +3079,7 @@ static int parse_index
         int64_t pos;
         int64_t pts;
         int64_t dts;
-        if( sscanf( buf, "Index=%d,POS=%" SCNd64 ",PTS=%" SCNd64 ",DTS=%" SCNd64 ",EDI=%d",
+        if( sscanf_unrolled1( buf, // "Index=%d,POS=%" SCNd64 ",PTS=%" SCNd64 ",DTS=%" SCNd64 ",EDI=%d",
                     &stream_index, &pos, &pts, &dts, &extradata_index ) != 5 )
             goto fail_parsing;
         if( !fgets( buf, sizeof(buf), index ) )
@@ -3109,7 +3111,7 @@ static int parse_index
                 int   poc;
                 int   repeat_pict;
                 int   field_info;
-                if( sscanf( buf, "Key=%d,Pic=%d,POC=%d,Repeat=%d,Field=%d",
+                if( sscanf_unrolled2( buf, // "Key=%d,Pic=%d,POC=%d,Repeat=%d,Field=%d",
                             &key, &pict_type, &poc, &repeat_pict, &field_info ) != 5 )
                     goto fail_parsing;
                 if( vdhp->codec_id == AV_CODEC_ID_NONE )
@@ -3191,7 +3193,8 @@ static int parse_index
                 char    *sample_fmt      = stream_info[stream_index].fmt;
                 int      bits_per_sample = stream_info[stream_index].bits_per_sample;
                 int      frame_length;
-                if( sscanf( buf, "Length=%d", &frame_length ) != 1 )
+                if( sscanf_unrolled3( buf, // "Length=%d"
+                            &frame_length ) != 1 )
                     goto fail_parsing;
                 if( adhp->codec_id == AV_CODEC_ID_NONE )
                     adhp->codec_id = (enum AVCodecID)codec_id;

--- a/common/lwindex_sscanf_unrolled.h
+++ b/common/lwindex_sscanf_unrolled.h
@@ -1,0 +1,166 @@
+/*****************************************************************************
+ * lwindex_sscanf_unrolled.h
+ *****************************************************************************
+ * Copyright (C) 2012-2025 L-SMASH Works project
+ *
+ * Authors: Xinyue Lu <i@7086.in>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *****************************************************************************/
+
+/* This file is available under an ISC license. */
+
+#include <ctype.h>
+#include <limits.h>
+
+#define PARSE_OR_RETURN(buf, needle, out, type) \
+    if (strncmp(buf, needle, strlen(needle)) != 0) \
+        return 0; \
+    buf += strlen(needle); \
+    out = my_strto_##type(buf, &buf); \
+    parsed_count++;
+
+#define CHECK_COMMA_OR_RETURN(p, parsed_count) \
+    if (*p != ',') \
+        return parsed_count; \
+    p++;
+
+static inline int64_t my_strto_int64_t(const char *nptr, char **endptr) {
+    const char *s = nptr;
+    int64_t acc;
+    int c;
+    int neg = 0;
+
+    /* Process sign. */
+    if (*s == '-') {
+        neg = 1;
+        s++;
+    } else if (*s == '+')
+        s++;
+
+    acc = 0;
+    for (;;s++) {
+        c = *s;
+        if (isdigit(c))
+            c -= '0';
+        else
+            break;
+        if (c >= 10)
+            break;
+        if (acc > (LLONG_MAX - c) / 10) {
+            acc = LLONG_MAX;
+            errno = ERANGE;
+            return neg ? LLONG_MIN : LLONG_MAX;
+        }
+        acc *= 10;
+        acc += c;
+    }
+    if (endptr != NULL)
+        *endptr = (char *)s;
+    return (neg ? -acc : acc);
+}
+
+static inline int my_strto_int(const char *nptr, char **endptr) {
+    const char *s = nptr;
+    int acc;
+    int c;
+    int neg = 0;
+
+    /* Process sign. */
+    if (*s == '-') {
+        neg = 1;
+        s++;
+    } else if (*s == '+')
+        s++;
+
+    acc = 0;
+    for (;;s++) {
+        c = *s;
+        if (isdigit(c))
+            c -= '0';
+        else
+            break;
+        if (c >= 10)
+            break;
+        if (acc > (INT_MAX - c) / 10) {
+            acc = INT_MAX;
+            errno = ERANGE;
+            return neg ? INT_MIN : INT_MAX;
+        }
+        acc *= 10;
+        acc += c;
+    }
+    if (endptr != NULL)
+        *endptr = (char *)s;
+    return (neg ? -acc : acc);
+}
+
+/*
+    Unroll the following sscanf:
+    sscanf( buf, "Index=%d,POS=%" SCNd64 ",PTS=%" SCNd64 ",DTS=%" SCNd64 ",EDI=%d",
+            &stream_index, &pos, &pts, &dts, &extradata_index )
+*/
+static inline int sscanf_unrolled1( const char *buf, int *stream_index, int64_t *pos, int64_t *pts, int64_t *dts, int *extradata_index )
+{
+    char *p = (char *)buf;
+    int parsed_count = 0;
+
+    PARSE_OR_RETURN(p, "Index=", *stream_index, int);
+    CHECK_COMMA_OR_RETURN(p, parsed_count);
+    PARSE_OR_RETURN(p, "POS=", *pos, int64_t);
+    CHECK_COMMA_OR_RETURN(p, parsed_count);
+    PARSE_OR_RETURN(p, "PTS=", *pts, int64_t);
+    CHECK_COMMA_OR_RETURN(p, parsed_count);
+    PARSE_OR_RETURN(p, "DTS=", *dts, int64_t);
+    CHECK_COMMA_OR_RETURN(p, parsed_count);
+    PARSE_OR_RETURN(p, "EDI=", *extradata_index, int);
+
+    return parsed_count;
+}
+
+/*
+    Unroll the following sscanf:
+    sscanf( buf, "Key=%d,Pic=%d,POC=%d,Repeat=%d,Field=%d",
+            &key, &pict_type, &poc, &repeat_pict, &field_info )
+*/
+static inline int sscanf_unrolled2( const char *buf, int *key, int *pict_type, int *poc, int *repeat_pict, int *field_info )
+{
+    char *p = (char *)buf;
+    int parsed_count = 0;
+
+    PARSE_OR_RETURN(p, "Key=", *key, int);
+    CHECK_COMMA_OR_RETURN(p, parsed_count);
+    PARSE_OR_RETURN(p, "Pic=", *pict_type, int);
+    CHECK_COMMA_OR_RETURN(p, parsed_count);
+    PARSE_OR_RETURN(p, "POC=", *poc, int);
+    CHECK_COMMA_OR_RETURN(p, parsed_count);
+    PARSE_OR_RETURN(p, "Repeat=", *repeat_pict, int);
+    CHECK_COMMA_OR_RETURN(p, parsed_count);
+    PARSE_OR_RETURN(p, "Field=", *field_info, int);
+
+    return parsed_count;
+}
+
+/*
+    Unroll the following sscanf:
+    sscanf( buf, "Length=%d", &frame_length )
+*/
+static inline int sscanf_unrolled3( const char *buf, int *frame_length )
+{
+    char *p = (char *)buf;
+    int parsed_count = 0;
+
+    PARSE_OR_RETURN(p, "Length=", *frame_length, int);
+
+    return parsed_count;
+}

--- a/common/lwindex_sscanf_unrolled.h
+++ b/common/lwindex_sscanf_unrolled.h
@@ -57,7 +57,7 @@ static inline int64_t my_strto_int64_t(const char *nptr, char **endptr) {
     acc = 0;
     for (;;s++) {
         c = *s;
-        if (isdigit(c))
+        if (c >= '0' && c <= '9')
             c -= '0';
         else
             break;
@@ -98,7 +98,7 @@ static inline int my_strto_int(const char *nptr, char **endptr) {
     acc = 0;
     for (;;s++) {
         c = *s;
-        if (isdigit(c))
+        if (c >= '0' && c <= '9')
             c -= '0';
         else
             break;
@@ -122,8 +122,7 @@ static inline int my_strto_int(const char *nptr, char **endptr) {
     sscanf( buf, "Index=%d,POS=%" SCNd64 ",PTS=%" SCNd64 ",DTS=%" SCNd64 ",EDI=%d",
             &stream_index, &pos, &pts, &dts, &extradata_index )
 */
-static inline int sscanf_unrolled1( const char *buf, int *stream_index, int64_t *pos, int64_t *pts, int64_t *dts, int *extradata_index )
-{
+static inline int sscanf_unrolled_main_index(const char *buf, int *stream_index, int64_t *pos, int64_t *pts, int64_t *dts, int *extradata_index) {
     char *p = (char *)buf;
     int parsed_count = 0;
 
@@ -145,8 +144,7 @@ static inline int sscanf_unrolled1( const char *buf, int *stream_index, int64_t 
     sscanf( buf, "Key=%d,Pic=%d,POC=%d,Repeat=%d,Field=%d",
             &key, &pict_type, &poc, &repeat_pict, &field_info )
 */
-static inline int sscanf_unrolled2( const char *buf, int *key, int *pict_type, int *poc, int *repeat_pict, int *field_info )
-{
+static inline int sscanf_unrolled_video_index(const char *buf, int *key, int *pict_type, int *poc, int *repeat_pict, int *field_info) {
     char *p = (char *)buf;
     int parsed_count = 0;
 
@@ -167,8 +165,7 @@ static inline int sscanf_unrolled2( const char *buf, int *key, int *pict_type, i
     Unroll the following sscanf:
     sscanf( buf, "Length=%d", &frame_length )
 */
-static inline int sscanf_unrolled3( const char *buf, int *frame_length )
-{
+static inline int sscanf_unrolled_audio_index(const char *buf, int *frame_length) {
     char *p = (char *)buf;
     int parsed_count = 0;
 

--- a/common/lwindex_sscanf_unrolled.h
+++ b/common/lwindex_sscanf_unrolled.h
@@ -25,7 +25,7 @@
 
 #define PARSE_OR_RETURN(buf, needle, out, type) \
     if (strncmp(buf, needle, strlen(needle)) != 0) \
-        return 0; \
+        return parsed_count; \
     buf += strlen(needle); \
     out = my_strto_##type(buf, &buf); \
     parsed_count++;
@@ -40,6 +40,12 @@ static inline int64_t my_strto_int64_t(const char *nptr, char **endptr) {
     int64_t acc;
     int c;
     int neg = 0;
+
+    const char* min_str = "-9223372036854775808";
+    if (strncmp(s, min_str, strlen(min_str)) == 0) {
+        *endptr = (char*)s + strlen(min_str);
+        return LLONG_MIN;
+    }
 
     /* Process sign. */
     if (*s == '-') {
@@ -75,6 +81,12 @@ static inline int my_strto_int(const char *nptr, char **endptr) {
     int acc;
     int c;
     int neg = 0;
+
+    const char* min_str = "-2147483648";
+    if (strncmp(s, min_str, strlen(min_str)) == 0) {
+        *endptr = (char*)s + strlen(min_str);
+        return INT_MIN;
+    }
 
     /* Process sign. */
     if (*s == '-') {


### PR DESCRIPTION
Most of the time in parse_index was spent in `sscanf`. I unrolled it into `strncmp` and `strtol` to improve performance.

(5s -> 1.3s for a 330MB lwi file.)