### PR TITLE
Fix partial audio gap rendering in AviSynth

### DIFF
--- a/AviSynth/lwlibav_source.cpp
+++ b/AviSynth/lwlibav_source.cpp
@@ -353,38 +353,64 @@ void __stdcall LWLibavAudioSource::GetAudio(void* buf, int64_t start, int64_t wa
     memset(buf, silence, (size_t)(wanted_length * aohp->output_block_align));
 }
 
+/* The gap list describes missing samples on the output timeline, but the source
+ * audio is packed as if those samples did not exist. Render a request as follows:
+ *
+ * 1. Fill the entire output buffer with silence, so every part covered by a gap
+ *    already has its final value.
+ * 2. Walk the ordered gap list and split the request into the non-gap ranges
+ *    before, between, and after the gaps. Decode only those ranges, leaving the
+ *    pre-filled silence untouched wherever the request overlaps a gap.
+ * 3. Before decoding each range, subtract the total length of all preceding gaps
+ *    from its output-timeline position. This maps that position back to the
+ *    corresponding sample in the packed source audio. Apply the normal audio
+ *    delay to each mapped range independently before asking the decoder for PCM.
+ *
+ * Return 1 when this function has rendered the whole request. Return 0 only when
+ * there is no gap list and GetAudio() must use its normal, single-range path. */
 int LWLibavAudioSource::fill_audio_gaps(void* buf, int64_t* start, int64_t wanted_length, lwlibav_audio_decode_handler_t* adhp,
     lwlibav_audio_output_handler_t* aohp, VideoInfo& vi)
 {
-    int64_t total_gap_length = 0;
     if (!adhp->gap_list)
         return 0;
-    int64_t current_start = *start;
+    if (wanted_length <= 0)
+        return 1;
+    const uint8_t silence = vi.sample_type == SAMPLE_INT8 ? 128 : 0;
+    memset(buf, silence, static_cast<size_t>(wanted_length * aohp->output_block_align));
+    const int64_t request_start = *start;
+    const int64_t request_end = request_start + wanted_length;
+    int64_t current_start = request_start;
+    int64_t total_gap_length = 0;
     for (int i = 0; i < adhp->gap_count; ++i) {
-        const int64_t pts_in_samples = adhp->gap_list[i].pts_in_samples;
-        const int gap_length = adhp->gap_list[i].length;
-        if (pts_in_samples + gap_length < current_start)
+        const int64_t gap_start = adhp->gap_list[i].pts_in_samples;
+        const int64_t gap_length = adhp->gap_list[i].length;
+        const int64_t gap_end = gap_start + gap_length;
+        if (gap_end <= current_start) {
             total_gap_length += gap_length;
-        else if (pts_in_samples > current_start + wanted_length)
+            continue;
+        }
+        if (gap_start >= request_end)
             break;
-        else {
-            const int64_t gap_start = pts_in_samples - current_start;
-            if (gap_start < wanted_length) {
-                const int64_t fill_start = MAX(0, gap_start);
-                const int64_t fill_end = MIN(wanted_length, gap_start + gap_length);
-                const int64_t fill_length = fill_end - fill_start;
-                const uint8_t silence = vi.sample_type == SAMPLE_INT8 ? 128 : 0;
-                memset(static_cast<uint8_t*>(buf) + fill_start * aohp->output_block_align, silence,
-                    static_cast<size_t>(fill_length * aohp->output_block_align));
-                wanted_length -= fill_length;
-                current_start += fill_length;
-                if (wanted_length <= 0)
-                    return 1;
+        if (gap_start > current_start) {
+            int64_t decode_start = current_start - total_gap_length;
+            const int64_t decode_length = gap_start - current_start;
+            if (delay_audio(&decode_start, decode_length)) {
+                (void)lwlibav_audio_get_pcm_samples(adhp, aohp,
+                    static_cast<uint8_t*>(buf) + (current_start - request_start) * aohp->output_block_align, decode_start, decode_length);
             }
         }
+        current_start = gap_end;
+        total_gap_length += gap_length;
+        if (current_start >= request_end)
+            return 1;
     }
-    *start -= total_gap_length;
-    return 0;
+    int64_t decode_start = current_start - total_gap_length;
+    const int64_t decode_length = request_end - current_start;
+    if (delay_audio(&decode_start, decode_length)) {
+        (void)lwlibav_audio_get_pcm_samples(adhp, aohp,
+            static_cast<uint8_t*>(buf) + (current_start - request_start) * aohp->output_block_align, decode_start, decode_length);
+    }
+    return 1;
 }
 
 static void set_av_log_level(int level)

--- a/AviSynth/lwlibav_source.cpp
+++ b/AviSynth/lwlibav_source.cpp
@@ -353,18 +353,18 @@ void __stdcall LWLibavAudioSource::GetAudio(void* buf, int64_t start, int64_t wa
     memset(buf, silence, (size_t)(wanted_length * aohp->output_block_align));
 }
 
-/* The gap list describes missing samples on the output timeline, but the source
- * audio is packed as if those samples did not exist. Render a request as follows:
+/* The gap list describes synthetic frames that occupy samples on the same
+ * timeline used by lwlibav_audio_get_pcm_samples(). Render a request as follows:
  *
  * 1. Fill the entire output buffer with silence, so every part covered by a gap
  *    already has its final value.
  * 2. Walk the ordered gap list and split the request into the non-gap ranges
  *    before, between, and after the gaps. Decode only those ranges, leaving the
  *    pre-filled silence untouched wherever the request overlaps a gap.
- * 3. Before decoding each range, subtract the total length of all preceding gaps
- *    from its output-timeline position. This maps that position back to the
- *    corresponding sample in the packed source audio. Apply the normal audio
- *    delay to each mapped range independently before asking the decoder for PCM.
+ * 3. Decode each non-gap range at its original timeline position. The synthetic
+ *    gap frames are included when the decoder counts PCM samples and locates the
+ *    starting frame, so preceding gap lengths must not be subtracted. Apply the
+ *    normal audio delay to each range before asking the decoder for PCM.
  *
  * Return 1 when this function has rendered the whole request. Return 0 only when
  * there is no gap list and GetAudio() must use its normal, single-range path. */
@@ -380,19 +380,16 @@ int LWLibavAudioSource::fill_audio_gaps(void* buf, int64_t* start, int64_t wante
     const int64_t request_start = *start;
     const int64_t request_end = request_start + wanted_length;
     int64_t current_start = request_start;
-    int64_t total_gap_length = 0;
     for (int i = 0; i < adhp->gap_count; ++i) {
         const int64_t gap_start = adhp->gap_list[i].pts_in_samples;
         const int64_t gap_length = adhp->gap_list[i].length;
         const int64_t gap_end = gap_start + gap_length;
-        if (gap_end <= current_start) {
-            total_gap_length += gap_length;
+        if (gap_end <= current_start)
             continue;
-        }
         if (gap_start >= request_end)
             break;
         if (gap_start > current_start) {
-            int64_t decode_start = current_start - total_gap_length;
+            int64_t decode_start = current_start;
             const int64_t decode_length = gap_start - current_start;
             if (delay_audio(&decode_start, decode_length)) {
                 (void)lwlibav_audio_get_pcm_samples(adhp, aohp,
@@ -400,11 +397,10 @@ int LWLibavAudioSource::fill_audio_gaps(void* buf, int64_t* start, int64_t wante
             }
         }
         current_start = gap_end;
-        total_gap_length += gap_length;
         if (current_start >= request_end)
             return 1;
     }
-    int64_t decode_start = current_start - total_gap_length;
+    int64_t decode_start = current_start;
     const int64_t decode_length = request_end - current_start;
     if (delay_audio(&decode_start, decode_length)) {
         (void)lwlibav_audio_get_pcm_samples(adhp, aohp,

--- a/AviSynth/lwlibav_source.cpp
+++ b/AviSynth/lwlibav_source.cpp
@@ -344,8 +344,6 @@ void __stdcall LWLibavAudioSource::GetAudio(void* buf, int64_t start, int64_t wa
     if (aohp->fill_audio_gaps) {
         if (fill_audio_gaps(buf, &start, wanted_length, adhp, aohp, vi))
             return;
-        if (wanted_length <= 0)
-            return;
     }
     if (delay_audio(&start, wanted_length))
         return (void)lwlibav_audio_get_pcm_samples(adhp, aohp, buf, start, wanted_length);


### PR DESCRIPTION
> Disclosure: This PR and report were prepared by OpenAI Codex, a GPT-based coding agent, after inspecting the code.
> The GitHub user posting this issue is forwarding the report and is not claiming authorship of the analysis and the code.

## Problem

The previous AviSynth `fill_agaps` implementation wrote silence into the part of an audio request that overlapped a synthetic gap.

When the request was only partially covered by a gap, `fill_audio_gaps()` returned to `GetAudio()`, which decoded the complete original request into the same buffer. This could overwrite the silence that had just been written.

The old implementation also subtracted the accumulated lengths of gaps preceding the request from the decode position. This was incorrect because `lwlibav_audio_get_pcm_samples()` counts samples and locates frames on a timeline that already includes the synthetic gap frames. Requests strictly after a gap could therefore be decoded from an earlier position.

Requests located entirely inside a gap worked because the function returned before the subsequent decode.

## Fix

The updated implementation renders the request in separate ranges:

1. Fill the complete output buffer with silence.
2. Walk the ordered gap list and identify the non-gap ranges before, between, and after the gaps.
3. Decode only those non-gap ranges, leaving the pre-filled gap regions untouched.
4. Decode every range at its original timeline position. Preceding gap lengths are not subtracted.
5. Apply the existing audio-delay handling independently to each decoded range.

This prevents a later decode from overwriting gap silence while preserving the coordinate system expected by the existing PCM decoder.

## Scope

This change is limited to the AviSynth `LWLibavAudioSource` gap-rendering path.

It does not change:

- the shared audio decoder;
- the index format;
- gap detection or gap-list construction;
- the existing handling of `rate=` resampling or nonzero `av_gap`.

The gap-list coordinate conversion under resampling and A/V delay remains a separate issue.

## Verification

A temporary standalone C++ wrapper was used to exercise the interval-splitting behavior without adding a test framework to the repository. It covered:

- requests without gaps;
- requests entirely inside a gap;
- left and right partial overlaps;
- a complete gap inside a request;
- gaps preceding a request;
- multiple gaps;
- exact gap boundaries;
- unsigned 8-bit silence;
- block alignment;
- empty requests.

The wrapper was updated to use the real gap-inclusive decoder coordinate semantics. It failed with the accumulated-gap subtraction and passed after that subtraction was removed.

The wrapper is not included in this PR and does not replace integration testing against the real decoder.

The AviSynth `LSMASHSource` Release target was also compiled successfully with the change.