### PR TITLE
Fix AviSynth audio-gap coordinates after resampling and A/V synchronization

### DIFF
--- a/AviSynth/lwlibav_source.cpp
+++ b/AviSynth/lwlibav_source.cpp
@@ -24,6 +24,10 @@
 #include <cstdio>
 #include <vector>
 
+extern "C" {
+#include <libavutil/mathematics.h>
+}
+
 #include "audio_output.h"
 #include "lwlibav_source.h"
 #include "video_output.h"
@@ -259,6 +263,13 @@ static void prepare_audio_decoding(lwlibav_audio_decode_handler_t* adhp, lwlibav
     lwlibav_audio_force_seek(adhp);
 }
 
+static uint64_t count_sequence_output_pcm_samples(uint64_t sequence_pcm_count, int current_sample_rate, int output_sample_rate)
+{
+    if (output_sample_rate == current_sample_rate)
+        return sequence_pcm_count;
+    return av_rescale_rnd(sequence_pcm_count, output_sample_rate, current_sample_rate, AV_ROUND_UP);
+}
+
 LWLibavAudioSource::LWLibavAudioSource(lwlibav_option_t* opt, const char* channel_layout, int sample_rate,
     const char* preferred_decoder_names, bool progress, const double drc, const char* ff_options, int fill_audio_gaps,
     IScriptEnvironment* env)
@@ -294,11 +305,27 @@ LWLibavAudioSource::LWLibavAudioSource(lwlibav_option_t* opt, const char* channe
     prepare_audio_decoding(adhp, aohp, channel_layout, sample_rate, lwh, vi, env);
     if (aohp->fill_audio_gaps && adhp->frame_list) {
         const audio_frame_info_t* const info = adhp->frame_list;
-        const AVRational sample_rate_tb = { 1, aohp->output_sample_rate };
         std::vector<std::pair<int64_t, int>> gap_info_list;
-        for (int i = 1; i < adhp->frame_count; ++i) {
+        int current_sample_rate = info[1].sample_rate > 0 ? info[1].sample_rate : adhp->ctx->sample_rate;
+        int current_frame_length = info[1].length;
+        uint64_t sequence_pcm_count = 0;
+        uint64_t prior_sequences_resampled_count = 0;
+        for (uint32_t i = 1; i < adhp->frame_count; ++i) {
+            if ((current_sample_rate != info[i].sample_rate && info[i].sample_rate > 0)
+                || current_frame_length != info[i].length) {
+                prior_sequences_resampled_count +=
+                    count_sequence_output_pcm_samples(sequence_pcm_count, current_sample_rate, aohp->output_sample_rate);
+                sequence_pcm_count = 0;
+                current_sample_rate = info[i].sample_rate > 0 ? info[i].sample_rate : adhp->ctx->sample_rate;
+                current_frame_length = info[i].length;
+            }
+            const uint64_t frame_start = prior_sequences_resampled_count
+                + count_sequence_output_pcm_samples(sequence_pcm_count, current_sample_rate, aohp->output_sample_rate);
+            sequence_pcm_count += info[i].length;
+            const uint64_t frame_end = prior_sequences_resampled_count
+                + count_sequence_output_pcm_samples(sequence_pcm_count, current_sample_rate, aohp->output_sample_rate);
             if (info[i].file_offset == -1)
-                gap_info_list.emplace_back(av_rescale_q(info[i].pts, adhp->time_base, sample_rate_tb), info[i].length);
+                gap_info_list.emplace_back((int64_t)frame_start, (int)(frame_end - frame_start));
         }
         const int gap_count = gap_info_list.size();
         if (gap_count > 0) {

--- a/AviSynth/lwlibav_source.cpp
+++ b/AviSynth/lwlibav_source.cpp
@@ -325,7 +325,7 @@ LWLibavAudioSource::LWLibavAudioSource(lwlibav_option_t* opt, const char* channe
             const uint64_t frame_end = prior_sequences_resampled_count
                 + count_sequence_output_pcm_samples(sequence_pcm_count, current_sample_rate, aohp->output_sample_rate);
             if (info[i].file_offset == -1)
-                gap_info_list.emplace_back((int64_t)frame_start + lwh.av_gap, (int)(frame_end - frame_start));
+                gap_info_list.emplace_back(static_cast<int64_t>(frame_start) + lwh.av_gap, static_cast<int>(frame_end - frame_start));
         }
         const int gap_count = gap_info_list.size();
         if (gap_count > 0) {

--- a/AviSynth/lwlibav_source.cpp
+++ b/AviSynth/lwlibav_source.cpp
@@ -257,7 +257,7 @@ static void prepare_audio_decoding(lwlibav_audio_decode_handler_t* adhp, lwlibav
     if (vi.num_audio_samples == 0)
         env->ThrowError("LWLibavAudioSource: no valid audio frame.");
     if (lwh.av_gap && aohp->output_sample_rate != ctx->sample_rate)
-        lwh.av_gap = ((int64_t)lwh.av_gap * aohp->output_sample_rate - 1) / ctx->sample_rate + 1;
+        lwh.av_gap = av_rescale_rnd(lwh.av_gap, aohp->output_sample_rate, ctx->sample_rate, AV_ROUND_UP);
     vi.num_audio_samples += lwh.av_gap;
     /* Force seeking at the first reading. */
     lwlibav_audio_force_seek(adhp);
@@ -325,7 +325,7 @@ LWLibavAudioSource::LWLibavAudioSource(lwlibav_option_t* opt, const char* channe
             const uint64_t frame_end = prior_sequences_resampled_count
                 + count_sequence_output_pcm_samples(sequence_pcm_count, current_sample_rate, aohp->output_sample_rate);
             if (info[i].file_offset == -1)
-                gap_info_list.emplace_back((int64_t)frame_start, (int)(frame_end - frame_start));
+                gap_info_list.emplace_back((int64_t)frame_start + lwh.av_gap, (int)(frame_end - frame_start));
         }
         const int gap_count = gap_info_list.size();
         if (gap_count > 0) {

--- a/AviSynth/lwlibav_source.cpp
+++ b/AviSynth/lwlibav_source.cpp
@@ -310,7 +310,7 @@ LWLibavAudioSource::LWLibavAudioSource(lwlibav_option_t* opt, const char* channe
         int current_frame_length = info[1].length;
         uint64_t sequence_pcm_count = 0;
         uint64_t prior_sequences_resampled_count = 0;
-        for (uint32_t i = 1; i < adhp->frame_count; ++i) {
+        for (uint32_t i = 1; i <= adhp->frame_count; ++i) {
             if ((current_sample_rate != info[i].sample_rate && info[i].sample_rate > 0)
                 || current_frame_length != info[i].length) {
                 prior_sequences_resampled_count +=


### PR DESCRIPTION
This issue is triggered when you do something like

```
LWLibavAudioSource("input.mkv", av_sync=true, rate=44100, fill_agaps=1)
```

---

>Disclosure: This PR and report were prepared by OpenAI Codex, a GPT-based coding agent, after inspecting the code.
>The GitHub user posting this issue is forwarding the report and is not claiming authorship of the analysis and the code.

## Summary

This PR fixes incorrect `fill_agaps` coordinates in `LWLibavAudioSource` when:

1. Audio is resampled through the `rate=` argument.
2. A/V synchronization produces a positive or negative `av_gap`.

The changes are limited to `AviSynth/lwlibav_source.cpp`.

## Problems

### 1. Resampled gap coordinates were inconsistent

The existing implementation converted the synthetic gap PTS to the requested output sample rate, but kept the gap length from the index without applying the same resampling rules.

This caused the gap start and length to use different coordinate systems.

The problem was especially visible when:

- `rate=` differed from the source sample rate;
- frame sequences had different sample rates or frame lengths;
- multiple sequences required independent rounding.

Per-frame conversion could also accumulate rounding drift because the decoder counts samples by sequence, not by independently converting every frame boundary.

### 2. Signed `av_gap` values were converted incorrectly

The previous conversion used:

```cpp
((int64_t)av_gap * output_rate - 1) / input_rate + 1
```

This is only correct for non-negative values. C++ integer division truncates negative results toward zero, so negative A/V offsets were rounded in the wrong direction.

In addition, the gap list was not shifted by the rescaled `av_gap`, so its coordinates did not match the timeline exposed by AviSynth `GetAudio()`.

## Solution

### Sequence-based resampling

The gap list is now built using the same sequence model as:

- `lwlibav_audio_count_overall_pcm_samples()`;
- `find_start_audio_frame()`.

Frames are grouped by sample rate and frame length. For each sequence:

1. Input PCM samples are accumulated.
2. The sequence boundary is rescaled with `av_rescale_rnd(..., AV_ROUND_UP)`.
3. Gap start and end positions are calculated from cumulative output coordinates.
4. The gap length is derived as `frame_end - frame_start`.

This keeps the gap list consistent with the decoder's output-sample counting and avoids cumulative rounding drift.

### Signed A/V gap conversion

`lwh.av_gap` is now rescaled with:

```cpp
av_rescale_rnd(lwh.av_gap, output_rate, input_rate, AV_ROUND_UP)
```

This preserves the intended mathematical ceiling behavior for both positive and negative values.

The rescaled value is then added to every gap start coordinate:

- positive `av_gap`: leading silence is shifted forward;
- negative `av_gap`: the gap begins earlier and may overlap the beginning of the output timeline.

## Commit Structure

The implementation is split into two logical commits:

1. Fix resampled audio gap coordinates.
2. Map audio gaps to the AviSynth timeline.

This keeps the resampling calculation and signed A/V timeline adjustment independently reviewable.

## Verification

The following checks were performed:

- Temporary ordinary C++ coordinate wrapper:
  - same-rate sequence;
  - changed frame-length sequence;
  - multiple gaps;
  - positive `av_gap`;
  - negative `av_gap`;
  - signed rescaling (`-100` samples at 48 kHz to 44.1 kHz becomes `-91`).
- Existing temporary audio-gap rendering wrapper:
  - 11 gap interval cases passed.
- Real AviSynth host integration:
  - 48 kHz source resampled to 44.1 kHz;
  - positive A/V offset;
  - negative A/V offset;
  - expected output sample counts and silent gap intervals verified.
- `git diff --check` passed.

The temporary wrappers and generated media used for verification are ignored and are not included in this PR.

## Scope

This PR only corrects gap coordinate construction, resampling rounding, and signed A/V timeline mapping.