### PR TITLE
Add VapourSynth audio source filters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,7 @@ if (BUILD_AVS_PLUGIN OR BUILD_VS_PLUGIN OR BUILD_AU2_PLUGIN)
         target_sources(LSMASHSource PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/common/planar_yuv_sse2.c")
     endif()
 
-    if (BUILD_AVS_PLUGIN OR BUILD_AU2_PLUGIN)
+    if (BUILD_AVS_PLUGIN OR BUILD_VS_PLUGIN OR BUILD_AU2_PLUGIN)
         target_sources(LSMASHSource PRIVATE
             "${CMAKE_CURRENT_SOURCE_DIR}/common/audio_output.c"
             "${CMAKE_CURRENT_SOURCE_DIR}/common/audio_output.h"
@@ -199,9 +199,13 @@ if (BUILD_AVS_PLUGIN OR BUILD_VS_PLUGIN OR BUILD_AU2_PLUGIN)
 
     if (BUILD_VS_PLUGIN)
         target_sources(LSMASHSource PRIVATE
+            "${CMAKE_CURRENT_SOURCE_DIR}/VapourSynth/audio_output.c"
+            "${CMAKE_CURRENT_SOURCE_DIR}/VapourSynth/audio_output.h"
+            "${CMAKE_CURRENT_SOURCE_DIR}/VapourSynth/libavsmash_audio_source.c"
             "${CMAKE_CURRENT_SOURCE_DIR}/VapourSynth/libavsmash_source.c"
             "${CMAKE_CURRENT_SOURCE_DIR}/VapourSynth/lsmashsource.c"
             "${CMAKE_CURRENT_SOURCE_DIR}/VapourSynth/lsmashsource.h"
+            "${CMAKE_CURRENT_SOURCE_DIR}/VapourSynth/lwlibav_audio_source.c"
             "${CMAKE_CURRENT_SOURCE_DIR}/VapourSynth/lwlibav_source.c"
             "${CMAKE_CURRENT_SOURCE_DIR}/VapourSynth/video_output.c"
             "${CMAKE_CURRENT_SOURCE_DIR}/VapourSynth/video_output.h"

--- a/VapourSynth/audio_output.c
+++ b/VapourSynth/audio_output.c
@@ -1,0 +1,120 @@
+/*****************************************************************************
+ * audio_output.c
+ *****************************************************************************/
+
+#include <libavutil/opt.h>
+#include <libswresample/swresample.h>
+
+#include <string.h>
+
+#include "audio_output.h"
+
+static enum AVSampleFormat decide_audio_output_sample_format(enum AVSampleFormat input_sample_format)
+{
+    switch (input_sample_format) {
+    case AV_SAMPLE_FMT_U8:
+    case AV_SAMPLE_FMT_U8P:
+        return AV_SAMPLE_FMT_U8;
+    case AV_SAMPLE_FMT_S16:
+    case AV_SAMPLE_FMT_S16P:
+        return AV_SAMPLE_FMT_S16;
+    case AV_SAMPLE_FMT_S32:
+    case AV_SAMPLE_FMT_S32P:
+        return AV_SAMPLE_FMT_S32;
+    default:
+        return AV_SAMPLE_FMT_FLT;
+    }
+}
+
+int vs_setup_audio_rendering(lw_audio_output_handler_t* aohp, AVCodecContext* ctx, const char* channel_layout, int sample_rate,
+    VSAudioInfo* ai, VSCore* core, const VSAPI* vsapi)
+{
+    if (!aohp || !ctx || !ai || !core || !vsapi)
+        return -1;
+    if (ctx->ch_layout.order == AV_CHANNEL_ORDER_UNSPEC)
+        av_channel_layout_default(&ctx->ch_layout, ctx->ch_layout.nb_channels);
+    if (channel_layout) {
+        av_channel_layout_uninit(&aohp->output_channel_layout);
+        if (av_channel_layout_from_string(&aohp->output_channel_layout, channel_layout) < 0)
+            return -1;
+    } else if (aohp->output_channel_layout.order == AV_CHANNEL_ORDER_UNSPEC || aohp->output_channel_layout.nb_channels == 0) {
+        if (av_channel_layout_copy(&aohp->output_channel_layout, &ctx->ch_layout) < 0)
+            return -1;
+    }
+    if (aohp->output_channel_layout.order != AV_CHANNEL_ORDER_NATIVE || !aohp->output_channel_layout.u.mask)
+        return -1;
+    if (sample_rate > 0)
+        aohp->output_sample_rate = sample_rate;
+    if (aohp->output_sample_rate <= 0)
+        aohp->output_sample_rate = ctx->sample_rate;
+
+    aohp->output_sample_format = decide_audio_output_sample_format(aohp->output_sample_format);
+    aohp->s24_output = 0;
+    aohp->output_bits_per_sample = av_get_bytes_per_sample(aohp->output_sample_format) * 8;
+    if (aohp->output_bits_per_sample <= 0)
+        return -1;
+
+    int input_channels = ctx->ch_layout.nb_channels;
+    if (av_sample_fmt_is_planar(ctx->sample_fmt)) {
+        aohp->input_planes = input_channels;
+        aohp->input_block_align = av_get_bytes_per_sample(ctx->sample_fmt);
+    } else {
+        aohp->input_planes = 1;
+        aohp->input_block_align = av_get_bytes_per_sample(ctx->sample_fmt) * input_channels;
+    }
+    aohp->output_block_align = aohp->output_channel_layout.nb_channels * av_get_bytes_per_sample(aohp->output_sample_format);
+    av_channel_layout_uninit(&aohp->input_channel_layout);
+    if (av_channel_layout_copy(&aohp->input_channel_layout, &ctx->ch_layout) < 0)
+        return -1;
+    aohp->input_sample_format = ctx->sample_fmt;
+    aohp->input_sample_rate = ctx->sample_rate;
+
+    swr_free(&aohp->swr_ctx);
+    aohp->swr_ctx = swr_alloc();
+    if (!aohp->swr_ctx)
+        return -1;
+    av_opt_set_chlayout(aohp->swr_ctx, "in_chlayout", &ctx->ch_layout, 0);
+    av_opt_set_sample_fmt(aohp->swr_ctx, "in_sample_fmt", ctx->sample_fmt, 0);
+    av_opt_set_int(aohp->swr_ctx, "in_sample_rate", ctx->sample_rate, 0);
+    av_opt_set_chlayout(aohp->swr_ctx, "out_chlayout", &aohp->output_channel_layout, 0);
+    av_opt_set_sample_fmt(aohp->swr_ctx, "out_sample_fmt", aohp->output_sample_format, 0);
+    av_opt_set_int(aohp->swr_ctx, "out_sample_rate", aohp->output_sample_rate, 0);
+    av_opt_set_sample_fmt(aohp->swr_ctx, "internal_sample_fmt", AV_SAMPLE_FMT_FLTP, 0);
+    if (swr_init(aohp->swr_ctx) < 0)
+        return -1;
+
+    memset(ai, 0, sizeof(*ai));
+    int sample_type = aohp->output_sample_format == AV_SAMPLE_FMT_FLT ? stFloat : stInteger;
+    if (!vsapi->queryAudioFormat(
+            &ai->format, sample_type, aohp->output_bits_per_sample, aohp->output_channel_layout.u.mask, core))
+        return -1;
+    ai->sampleRate = aohp->output_sample_rate;
+    return 0;
+}
+
+VSFrame* vs_interleaved_audio_frame(
+    const lw_audio_output_handler_t* aohp, const uint8_t* interleaved, int sample_count, VSCore* core, const VSAPI* vsapi)
+{
+    if (!aohp || !interleaved || sample_count <= 0 || !core || !vsapi)
+        return NULL;
+    const int channels = aohp->output_channel_layout.nb_channels;
+    const int bytes_per_sample = av_get_bytes_per_sample(aohp->output_sample_format);
+    if (channels <= 0 || bytes_per_sample <= 0)
+        return NULL;
+
+    VSAudioFormat format;
+    int sample_type = aohp->output_sample_format == AV_SAMPLE_FMT_FLT ? stFloat : stInteger;
+    if (!vsapi->queryAudioFormat(
+            &format, sample_type, bytes_per_sample * 8, aohp->output_channel_layout.u.mask, core))
+        return NULL;
+    VSFrame* frame = vsapi->newAudioFrame(&format, sample_count, NULL, core);
+    if (!frame)
+        return NULL;
+    for (int channel = 0; channel < channels; channel++) {
+        uint8_t* dst = vsapi->getWritePtr(frame, channel);
+        for (int sample = 0; sample < sample_count; sample++)
+            memcpy(dst + (size_t)sample * bytes_per_sample,
+                interleaved + ((size_t)sample * channels + channel) * bytes_per_sample, bytes_per_sample);
+    }
+    return frame;
+}

--- a/VapourSynth/audio_output.h
+++ b/VapourSynth/audio_output.h
@@ -1,0 +1,18 @@
+/*****************************************************************************
+ * audio_output.h
+ *****************************************************************************/
+
+#ifndef VS_AUDIO_OUTPUT_H
+#define VS_AUDIO_OUTPUT_H
+
+#include <VapourSynth4.h>
+
+#include "../common/audio_output.h"
+
+int vs_setup_audio_rendering(lw_audio_output_handler_t* aohp, AVCodecContext* ctx, const char* channel_layout, int sample_rate,
+    VSAudioInfo* ai, VSCore* core, const VSAPI* vsapi);
+
+VSFrame* vs_interleaved_audio_frame(
+    const lw_audio_output_handler_t* aohp, const uint8_t* interleaved, int sample_count, VSCore* core, const VSAPI* vsapi);
+
+#endif // !VS_AUDIO_OUTPUT_H

--- a/VapourSynth/libavsmash_audio_source.c
+++ b/VapourSynth/libavsmash_audio_source.c
@@ -1,0 +1,282 @@
+/*****************************************************************************
+ * libavsmash_audio_source.c
+ *****************************************************************************/
+
+#include <inttypes.h>
+#include <stdlib.h>
+
+#include <lsmash.h>
+
+#include <libavformat/avformat.h>
+#include <libavutil/log.h>
+#include <libavutil/mem.h>
+#include <libavutil/mathematics.h>
+
+#include "audio_output.h"
+#include "lsmashsource.h"
+
+#include "../common/libavsmash.h"
+#include "../common/libavsmash_audio.h"
+
+typedef struct {
+    VSAudioInfo ai;
+    libavsmash_audio_decode_handler_t* adhp;
+    libavsmash_audio_output_handler_t* aohp;
+    lsmash_file_parameters_t file_param;
+    AVFormatContext* format_ctx;
+    char preferred_decoder_names_buf[PREFERRED_DECODER_NAMES_BUFSIZE];
+} lsmas_audio_handler_t;
+
+static void free_handler(lsmas_audio_handler_t** hpp)
+{
+    if (!hpp || !*hpp)
+        return;
+    lsmas_audio_handler_t* hp = *hpp;
+    lsmash_root_t* root = hp->adhp ? libavsmash_audio_get_root(hp->adhp) : NULL;
+    if (hp->adhp)
+        lw_free(libavsmash_audio_get_preferred_decoder_names(hp->adhp));
+    libavsmash_audio_free_decode_handler(hp->adhp);
+    if (hp->aohp) {
+        av_channel_layout_uninit(&hp->aohp->input_channel_layout);
+        av_channel_layout_uninit(&hp->aohp->output_channel_layout);
+    }
+    libavsmash_audio_free_output_handler(hp->aohp);
+    avformat_close_input(&hp->format_ctx);
+    lsmash_close_file(&hp->file_param);
+    if (root)
+        lsmash_destroy_root(root);
+    lw_free(hp);
+    *hpp = NULL;
+}
+
+static lsmas_audio_handler_t* alloc_handler(void)
+{
+    lsmas_audio_handler_t* hp = (lsmas_audio_handler_t*)lw_malloc_zero(sizeof(*hp));
+    if (!hp)
+        return NULL;
+    hp->adhp = libavsmash_audio_alloc_decode_handler();
+    hp->aohp = libavsmash_audio_alloc_output_handler();
+    if (!hp->adhp || !hp->aohp) {
+        free_handler(&hp);
+        return NULL;
+    }
+    return hp;
+}
+
+static int64_t get_start_time(lsmash_root_t* root, uint32_t track_id)
+{
+    uint32_t edit_count = lsmash_count_explicit_timeline_map(root, track_id);
+    for (uint32_t edit_number = 1; edit_number <= edit_count; edit_number++) {
+        lsmash_edit_t edit;
+        if (lsmash_get_explicit_timeline_map(root, track_id, edit_number, &edit) || edit.duration == 0)
+            return 0;
+        if (edit.start_time >= 0)
+            return edit.start_time;
+    }
+    return 0;
+}
+
+static char* duplicate_string(const void* src, size_t length)
+{
+    char* dst = (char*)malloc(length + 1);
+    if (!dst)
+        return NULL;
+    memcpy(dst, src, length);
+    dst[length] = '\0';
+    return dst;
+}
+
+static int count_output_audio_samples(lsmas_audio_handler_t* hp, int skip_priming, VSMap* out, const VSAPI* vsapi)
+{
+    libavsmash_audio_decode_handler_t* adhp = hp->adhp;
+    libavsmash_audio_output_handler_t* aohp = hp->aohp;
+    lsmash_root_t* root = libavsmash_audio_get_root(adhp);
+    uint32_t track_id = libavsmash_audio_get_track_id(adhp);
+    uint64_t start_time = 0;
+    if (skip_priming) {
+        uint32_t media_timescale = libavsmash_audio_get_media_timescale(adhp);
+        uint32_t metadata_count = lsmash_count_itunes_metadata(root);
+        for (uint32_t i = 1; i <= metadata_count; i++) {
+            lsmash_itunes_metadata_t metadata;
+            if (lsmash_get_itunes_metadata(root, i, &metadata) < 0)
+                continue;
+            int matches = metadata.item == ITUNES_METADATA_ITEM_CUSTOM
+                && (metadata.type == ITUNES_METADATA_TYPE_STRING || metadata.type == ITUNES_METADATA_TYPE_BINARY) && metadata.meaning
+                && metadata.name && !strcmp(metadata.meaning, "com.apple.iTunes") && !strcmp(metadata.name, "iTunSMPB");
+            char* value = NULL;
+            if (matches && metadata.type == ITUNES_METADATA_TYPE_STRING) {
+                size_t length = strlen(metadata.value.string);
+                if (length >= 116)
+                    value = duplicate_string(metadata.value.string, length);
+            } else if (matches && metadata.value.binary.size >= 116)
+                value = duplicate_string(metadata.value.binary.data, metadata.value.binary.size);
+            lsmash_cleanup_itunes_metadata(&metadata);
+            if (!value)
+                continue;
+            uint32_t dummy[9];
+            uint32_t priming_samples;
+            uint32_t padding;
+            uint64_t duration;
+            int fields = sscanf(value, " %x %x %x %" SCNx64 " %x %x %x %x %x %x %x %x", &dummy[0], &priming_samples, &padding,
+                &duration, &dummy[1], &dummy[2], &dummy[3], &dummy[4], &dummy[5], &dummy[6], &dummy[7], &dummy[8]);
+            lw_free(value);
+            if (fields != 12)
+                continue;
+            libavsmash_audio_set_implicit_preroll(adhp);
+            start_time = av_rescale(priming_samples, media_timescale, aohp->output_sample_rate);
+            aohp->skip_decoded_samples = priming_samples;
+            break;
+        }
+        if (aohp->skip_decoded_samples == 0) {
+            uint32_t ctd_shift;
+            if (lsmash_get_composition_to_decode_shift_from_media_timeline(root, track_id, &ctd_shift)) {
+                set_error_on_init(out, vsapi, "lsmas: failed to get the audio timeline shift.");
+                return -1;
+            }
+            start_time = ctd_shift + get_start_time(root, track_id);
+            aohp->skip_decoded_samples = av_rescale(start_time, aohp->output_sample_rate, media_timescale);
+        }
+    }
+    hp->ai.numSamples = libavsmash_audio_count_overall_pcm_samples(adhp, aohp->output_sample_rate, start_time);
+    if (hp->ai.numSamples <= 0) {
+        set_error_on_init(out, vsapi, "lsmas: no valid audio frame.");
+        return -1;
+    }
+    hp->ai.numFrames = (int)((hp->ai.numSamples + VS_AUDIO_FRAME_SAMPLES - 1) / VS_AUDIO_FRAME_SAMPLES);
+    return 0;
+}
+
+static const VSFrame* VS_CC audio_get_frame(
+    int n, int activation_reason, void* instance_data, void** frame_data, VSFrameContext* frame_ctx, VSCore* core, const VSAPI* vsapi)
+{
+    if (activation_reason != arInitial)
+        return NULL;
+    lsmas_audio_handler_t* hp = (lsmas_audio_handler_t*)instance_data;
+    int64_t start = (int64_t)n * VS_AUDIO_FRAME_SAMPLES;
+    int sample_count = (int)MIN((int64_t)VS_AUDIO_FRAME_SAMPLES, hp->ai.numSamples - start);
+    if (sample_count <= 0) {
+        vsapi->setFilterError("lsmas: requested audio frame is out of range.", frame_ctx);
+        return NULL;
+    }
+
+    vs_basic_handler_t vsbh = { 0 };
+    vsbh.frame_ctx = frame_ctx;
+    vsbh.vsapi = vsapi;
+    lw_log_handler_t* lhp = libavsmash_audio_get_log_handler(hp->adhp);
+    lhp->priv = &vsbh;
+    lhp->show_log = set_error;
+
+    size_t buffer_size = (size_t)sample_count * hp->aohp->output_block_align;
+    uint8_t* buffer = (uint8_t*)av_malloc(buffer_size);
+    if (!buffer) {
+        vsapi->setFilterError("lsmas: failed to allocate an audio buffer.", frame_ctx);
+        return NULL;
+    }
+    memset(buffer, hp->aohp->output_bits_per_sample == 8 ? 0x80 : 0, buffer_size);
+    uint64_t output_count = libavsmash_audio_get_pcm_samples(hp->adhp, hp->aohp, buffer, start, sample_count);
+    if (output_count != (uint64_t)sample_count || libavsmash_audio_get_error(hp->adhp)) {
+        av_free(buffer);
+        vsapi->setFilterError("lsmas: failed to output an audio frame.", frame_ctx);
+        return NULL;
+    }
+    VSFrame* frame = vs_interleaved_audio_frame(hp->aohp, buffer, sample_count, core, vsapi);
+    av_free(buffer);
+    if (!frame)
+        vsapi->setFilterError("lsmas: failed to create an audio frame.", frame_ctx);
+    return frame;
+}
+
+static void VS_CC audio_free(void* instance_data, VSCore* core, const VSAPI* vsapi)
+{
+    free_handler((lsmas_audio_handler_t**)&instance_data);
+}
+
+static void set_av_log_level(int64_t level)
+{
+    static const int levels[] = { AV_LOG_QUIET, AV_LOG_PANIC, AV_LOG_FATAL, AV_LOG_ERROR, AV_LOG_WARNING, AV_LOG_INFO, AV_LOG_VERBOSE,
+        AV_LOG_DEBUG, AV_LOG_TRACE };
+    av_log_set_level(level <= 0 ? levels[0] : levels[MIN(level, 8)]);
+}
+
+void VS_CC vs_libavsmashaudiosource_create(const VSMap* in, VSMap* out, void* user_data, VSCore* core, const VSAPI* vsapi)
+{
+    const char* source = vsapi->mapGetData(in, "source", 0, NULL);
+    int64_t track;
+    int64_t skip_priming;
+    int64_t rate;
+    int64_t ff_loglevel;
+    const char* layout;
+    const char* decoder;
+    const char* ff_options;
+    int error;
+    double drc = vsapi->mapGetFloat(in, "drc_scale", 0, &error);
+    if (error)
+        drc = -1.0;
+    set_option_int64(&track, 0, "track", in, vsapi);
+    set_option_int64(&skip_priming, 1, "skip_priming", in, vsapi);
+    set_option_int64(&rate, 0, "rate", in, vsapi);
+    set_option_int64(&ff_loglevel, 0, "ff_loglevel", in, vsapi);
+    set_option_string(&layout, NULL, "layout", in, vsapi);
+    set_option_string(&decoder, NULL, "decoder", in, vsapi);
+    set_option_string(&ff_options, NULL, "ff_options", in, vsapi);
+    set_av_log_level(ff_loglevel);
+
+    lsmas_audio_handler_t* hp = alloc_handler();
+    if (!hp) {
+        vsapi->mapSetError(out, "lsmas: failed to allocate the LibavSMASH audio handler.");
+        return;
+    }
+    vs_basic_handler_t vsbh = { out, NULL, vsapi };
+    lw_log_handler_t* lhp = libavsmash_audio_get_log_handler(hp->adhp);
+    lhp->name = "LibavSMASHAudioSource";
+    lhp->level = LW_LOG_FATAL;
+    lhp->priv = &vsbh;
+    lhp->show_log = set_error;
+    set_preferred_decoder_names_on_buf(hp->preferred_decoder_names_buf, decoder);
+    libavsmash_audio_set_preferred_decoder_names(hp->adhp, tokenize_preferred_decoder_names(hp->preferred_decoder_names_buf));
+    libavsmash_audio_set_drc(hp->adhp, drc);
+    libavsmash_audio_set_decoder_options(hp->adhp, ff_options);
+
+    lsmash_movie_parameters_t movie_param;
+    lsmash_root_t* root = libavsmash_open_file(&hp->format_ctx, source, &hp->file_param, &movie_param, lhp);
+    if (!root) {
+        free_handler(&hp);
+        set_error_on_init(out, vsapi, "lsmas: failed to open %s.", source);
+        return;
+    }
+    libavsmash_audio_set_root(hp->adhp, root);
+    if ((track > 0 && track > movie_param.number_of_tracks) || libavsmash_audio_get_track(hp->adhp, (uint32_t)track) < 0) {
+        free_handler(&hp);
+        set_error_on_init(out, vsapi, "lsmas: failed to get the requested audio track.");
+        return;
+    }
+    if (libavsmash_audio_initialize_decoder_configuration(hp->adhp, hp->format_ctx, 0) < 0) {
+        free_handler(&hp);
+        set_error_on_init(out, vsapi, "lsmas: failed to initialize the audio decoder configuration.");
+        return;
+    }
+    av_channel_layout_from_mask(&hp->aohp->output_channel_layout, libavsmash_audio_get_best_used_channel_layout(hp->adhp));
+    hp->aohp->output_sample_format = libavsmash_audio_get_best_used_sample_format(hp->adhp);
+    hp->aohp->output_sample_rate = libavsmash_audio_get_best_used_sample_rate(hp->adhp);
+    hp->aohp->output_bits_per_sample = libavsmash_audio_get_best_used_bits_per_sample(hp->adhp);
+    AVCodecContext* ctx = libavsmash_audio_get_codec_context(hp->adhp);
+    if (vs_setup_audio_rendering(hp->aohp, ctx, layout, (int)MAX(rate, 0), &hp->ai, core, vsapi) < 0
+        || count_output_audio_samples(hp, skip_priming != 0, out, vsapi) < 0) {
+        free_handler(&hp);
+        if (!vsapi->mapGetError(out))
+            set_error_on_init(out, vsapi, "lsmas: failed to configure audio output.");
+        return;
+    }
+    libavsmash_audio_force_seek(hp->adhp);
+    lsmash_discard_boxes(root);
+
+    VSNode* node = vsapi->createAudioFilter2(
+        "LibavSMASHAudioSource", &hp->ai, audio_get_frame, audio_free, fmUnordered, NULL, 0, hp, core);
+    if (!node) {
+        free_handler(&hp);
+        vsapi->mapSetError(out, "lsmas: failed to create the LibavSMASH audio node.");
+        return;
+    }
+    vsapi->setLinearFilter(node);
+    vsapi->mapConsumeNode(out, "audio", node, maAppend);
+}

--- a/VapourSynth/lsmashsource.c
+++ b/VapourSynth/lsmashsource.c
@@ -51,6 +51,8 @@ void set_error_on_init(VSMap* out, const VSAPI* vsapi, const char* format, ...)
 
 extern void VS_CC vs_libavsmashsource_create(const VSMap* in, VSMap* out, void* user_data, VSCore* core, const VSAPI* vsapi);
 extern void VS_CC vs_lwlibavsource_create(const VSMap* in, VSMap* out, void* user_data, VSCore* core, const VSAPI* vsapi);
+extern void VS_CC vs_libavsmashaudiosource_create(const VSMap* in, VSMap* out, void* user_data, VSCore* core, const VSAPI* vsapi);
+extern void VS_CC vs_lwlibavaudiosource_create(const VSMap* in, VSMap* out, void* user_data, VSCore* core, const VSAPI* vsapi);
 
 /*void VS_CC vs_version_create( const VSMap *in, VSMap *out, void *user_data, VSCore *core, const VSAPI *vsapi )
 {
@@ -72,9 +74,17 @@ VS_EXTERNAL_API(void) VapourSynthPluginInit2(VSPlugin* plugin, const VSPLUGINAPI
     "decoder:data:opt;prefer_hw:int:opt;"
     vspapi->registerFunction("LibavSMASHSource", "source:data;track:int:opt;" COMMON_OPTS "ff_loglevel:int:opt;ff_options:data:opt;",
         "clip:vnode;", vs_libavsmashsource_create, NULL, plugin);
+    vspapi->registerFunction("LibavSMASHAudioSource",
+        "source:data;track:int:opt;skip_priming:int:opt;layout:data:opt;rate:int:opt;decoder:data:opt;ff_loglevel:int:opt;drc_scale:"
+        "float:opt;ff_options:data:opt;",
+        "audio:anode;", vs_libavsmashaudiosource_create, NULL, plugin);
     vspapi->registerFunction("LWLibavSource",
         "source:data;stream_index:int:opt;cache:int:opt;cachefile:data:opt;" COMMON_OPTS
         "repeat:int:opt;dominance:int:opt;ff_loglevel:int:opt;cachedir:data:opt;ff_options:data:opt;rap_verification:int:opt;",
         "clip:vnode;", vs_lwlibavsource_create, NULL, plugin);
+    vspapi->registerFunction("LWLibavAudioSource",
+        "source:data;stream_index:int:opt;cache:int:opt;cachefile:data:opt;av_sync:int:opt;layout:data:opt;rate:int:opt;decoder:data:opt;"
+        "ff_loglevel:int:opt;cachedir:data:opt;indexingpr:int:opt;drc_scale:float:opt;ff_options:data:opt;fill_agaps:int:opt;",
+        "audio:anode;", vs_lwlibavaudiosource_create, NULL, plugin);
 #undef COMMON_OPTS
 }

--- a/VapourSynth/lwlibav_audio_source.c
+++ b/VapourSynth/lwlibav_audio_source.c
@@ -153,7 +153,11 @@ static int decode_audio_range(uint8_t* buf, int64_t output_start, int64_t length
     int64_t source_start = output_start;
     if (!delay_audio(hp, &source_start, length))
         return 0;
-    return lwlibav_audio_get_pcm_samples(hp->adhp, hp->aohp, buf, source_start, length) == (uint64_t)length ? 0 : -1;
+    uint64_t output_length = lwlibav_audio_get_pcm_samples(hp->adhp, hp->aohp, buf, source_start, length);
+    if (output_length == (uint64_t)length)
+        return 0;
+    /* Index-derived lengths can include decoder-delay samples at EOF. The caller pre-fills that remainder with silence. */
+    return !hp->adhp->error && output_start == hp->ai.numSamples - length ? 0 : -1;
 }
 
 static int render_audio(uint8_t* buf, int64_t start, int64_t wanted_length, lwlibav_audio_handler_t* hp)

--- a/VapourSynth/lwlibav_audio_source.c
+++ b/VapourSynth/lwlibav_audio_source.c
@@ -1,0 +1,362 @@
+/*****************************************************************************
+ * lwlibav_audio_source.c
+ *****************************************************************************/
+
+#include <stdio.h>
+#include <string.h>
+#include <limits.h>
+
+#include <libavutil/log.h>
+#include <libavutil/mem.h>
+#include <libavutil/mathematics.h>
+
+#include "audio_output.h"
+#include "lsmashsource.h"
+
+#include "../common/lwindex.h"
+#include "../common/lwlibav_audio.h"
+#include "../common/lwlibav_audio_internal.h"
+#include "../common/lwlibav_video.h"
+#include "../common/progress.h"
+
+typedef struct {
+    VSAudioInfo ai;
+    lwlibav_file_handler_t lwh;
+    lwlibav_audio_decode_handler_t* adhp;
+    lwlibav_audio_output_handler_t* aohp;
+    lwlibav_video_decode_handler_t* vdhp;
+    lwlibav_video_output_handler_t* vohp;
+    char preferred_decoder_names_buf[PREFERRED_DECODER_NAMES_BUFSIZE];
+} lwlibav_audio_handler_t;
+
+static void free_handler(lwlibav_audio_handler_t** hpp)
+{
+    if (!hpp || !*hpp)
+        return;
+    lwlibav_audio_handler_t* hp = *hpp;
+    if (hp->adhp) {
+        lw_free(hp->adhp->gap_list);
+        lw_free(lwlibav_audio_get_preferred_decoder_names(hp->adhp));
+    }
+    lwlibav_audio_free_decode_handler(hp->adhp);
+    if (hp->aohp) {
+        av_channel_layout_uninit(&hp->aohp->input_channel_layout);
+        av_channel_layout_uninit(&hp->aohp->output_channel_layout);
+    }
+    lwlibav_audio_free_output_handler(hp->aohp);
+    lwlibav_video_free_decode_handler(hp->vdhp);
+    lwlibav_video_free_output_handler(hp->vohp);
+    lw_free(hp->lwh.file_path);
+    lw_free(hp);
+    *hpp = NULL;
+}
+
+static lwlibav_audio_handler_t* alloc_handler(void)
+{
+    lwlibav_audio_handler_t* hp = (lwlibav_audio_handler_t*)lw_malloc_zero(sizeof(*hp));
+    if (!hp)
+        return NULL;
+    hp->adhp = lwlibav_audio_alloc_decode_handler();
+    hp->aohp = lwlibav_audio_alloc_output_handler();
+    hp->vdhp = lwlibav_video_alloc_decode_handler();
+    hp->vohp = lwlibav_video_alloc_output_handler();
+    if (!hp->adhp || !hp->aohp || !hp->vdhp || !hp->vohp) {
+        free_handler(&hp);
+        return NULL;
+    }
+    return hp;
+}
+
+static int update_indicator(progress_handler_t* php, const char* message, int percent)
+{
+    static int last_percent = -1;
+    if (!strcmp(message, "Creating Index file") && last_percent != percent) {
+        last_percent = percent;
+        fprintf(stderr, "Creating lwi index file %d%%\r", percent);
+        fflush(stderr);
+    }
+    return 0;
+}
+
+static void close_indicator(progress_handler_t* php)
+{
+    fprintf(stderr, "\n");
+}
+
+static int make_gap_list(lwlibav_audio_handler_t* hp, VSMap* out, const VSAPI* vsapi)
+{
+    lwlibav_audio_decode_handler_t* adhp = hp->adhp;
+    if (!hp->aohp->fill_audio_gaps || !adhp->frame_list)
+        return 0;
+    const audio_frame_info_t* info = adhp->frame_list;
+    int gap_count = 0;
+    for (uint32_t i = 1; i < adhp->frame_count; i++) {
+        if (info[i].file_offset == -1)
+            gap_count++;
+    }
+    if (!gap_count)
+        return 0;
+    adhp->gap_list = (lw_audio_gap_info_t*)lw_malloc_zero((size_t)gap_count * sizeof(*adhp->gap_list));
+    if (!adhp->gap_list) {
+        set_error_on_init(out, vsapi, "lsmas: failed to allocate the audio gap list.");
+        return -1;
+    }
+    int current_sample_rate = info[1].sample_rate > 0 ? info[1].sample_rate : hp->adhp->ctx->sample_rate;
+    int current_frame_length = info[1].length;
+    uint64_t sequence_sample_count = 0;
+    uint64_t prior_sequence_sample_count = 0;
+    int gap_index = 0;
+    for (uint32_t i = 1; i < adhp->frame_count; i++) {
+        if ((current_sample_rate != info[i].sample_rate && info[i].sample_rate > 0) || current_frame_length != info[i].length) {
+            prior_sequence_sample_count += av_rescale_rnd(
+                sequence_sample_count, hp->aohp->output_sample_rate, current_sample_rate, AV_ROUND_UP);
+            sequence_sample_count = 0;
+            current_sample_rate = info[i].sample_rate > 0 ? info[i].sample_rate : hp->adhp->ctx->sample_rate;
+            current_frame_length = info[i].length;
+        }
+        if (info[i].file_offset == -1) {
+            int64_t gap_start = prior_sequence_sample_count
+                + av_rescale_rnd(sequence_sample_count, hp->aohp->output_sample_rate, current_sample_rate, AV_ROUND_UP);
+            int64_t gap_end = prior_sequence_sample_count
+                + av_rescale_rnd(
+                    sequence_sample_count + info[i].length, hp->aohp->output_sample_rate, current_sample_rate, AV_ROUND_UP);
+            int64_t gap_length = gap_end - gap_start;
+            if (gap_length <= 0 || gap_length > INT_MAX) {
+                set_error_on_init(out, vsapi, "lsmas: the resampled audio gap is too large.");
+                return -1;
+            }
+            adhp->gap_list[gap_index].pts_in_samples = gap_start;
+            adhp->gap_list[gap_index].length = (int)gap_length;
+            gap_index++;
+        }
+        sequence_sample_count += info[i].length;
+    }
+    adhp->gap_count = gap_count;
+    return 0;
+}
+
+static int delay_audio(lwlibav_audio_handler_t* hp, int64_t* start, int64_t wanted_length)
+{
+    int64_t end = *start + wanted_length;
+    int64_t audio_delay = hp->lwh.av_gap;
+    if (*start < audio_delay && end <= audio_delay) {
+        lwlibav_audio_force_seek(hp->adhp);
+        return 0;
+    }
+    *start -= audio_delay;
+    return 1;
+}
+
+static int decode_audio_range(
+    uint8_t* buf, int64_t output_start, int64_t length, int64_t removed_gap_length, lwlibav_audio_handler_t* hp)
+{
+    int64_t source_start = output_start - removed_gap_length;
+    if (!delay_audio(hp, &source_start, length))
+        return 0;
+    return lwlibav_audio_get_pcm_samples(hp->adhp, hp->aohp, buf, source_start, length) == (uint64_t)length ? 0 : -1;
+}
+
+static int render_audio(uint8_t* buf, int64_t start, int64_t wanted_length, lwlibav_audio_handler_t* hp)
+{
+    lwlibav_audio_decode_handler_t* adhp = hp->adhp;
+    lwlibav_audio_output_handler_t* aohp = hp->aohp;
+    if (!aohp->fill_audio_gaps || !adhp->gap_list)
+        return decode_audio_range(buf, start, wanted_length, 0, hp);
+
+    int64_t end = start + wanted_length;
+    int64_t cursor = start;
+    int64_t removed_gap_length = 0;
+    for (int i = 0; i < adhp->gap_count; i++) {
+        int64_t gap_start = adhp->gap_list[i].pts_in_samples + hp->lwh.av_gap;
+        int64_t gap_length = adhp->gap_list[i].length;
+        int64_t gap_end = gap_start + gap_length;
+        if (gap_end <= cursor) {
+            removed_gap_length += gap_length;
+            continue;
+        }
+        if (gap_start >= end)
+            break;
+        if (gap_start > cursor) {
+            int64_t decode_length = MIN(gap_start, end) - cursor;
+            uint8_t* decode_buf = buf + (cursor - start) * aohp->output_block_align;
+            if (decode_audio_range(decode_buf, cursor, decode_length, removed_gap_length, hp) < 0)
+                return -1;
+        }
+        cursor = MAX(cursor, gap_end);
+        removed_gap_length += gap_length;
+        if (cursor >= end)
+            return 0;
+    }
+    if (cursor < end) {
+        uint8_t* decode_buf = buf + (cursor - start) * aohp->output_block_align;
+        if (decode_audio_range(decode_buf, cursor, end - cursor, removed_gap_length, hp) < 0)
+            return -1;
+    }
+    return 0;
+}
+
+static const VSFrame* VS_CC audio_get_frame(
+    int n, int activation_reason, void* instance_data, void** frame_data, VSFrameContext* frame_ctx, VSCore* core, const VSAPI* vsapi)
+{
+    if (activation_reason != arInitial)
+        return NULL;
+    lwlibav_audio_handler_t* hp = (lwlibav_audio_handler_t*)instance_data;
+    int64_t start = (int64_t)n * VS_AUDIO_FRAME_SAMPLES;
+    int sample_count = (int)MIN((int64_t)VS_AUDIO_FRAME_SAMPLES, hp->ai.numSamples - start);
+    if (sample_count <= 0) {
+        vsapi->setFilterError("lsmas: requested audio frame is out of range.", frame_ctx);
+        return NULL;
+    }
+
+    vs_basic_handler_t vsbh = { 0 };
+    vsbh.frame_ctx = frame_ctx;
+    vsbh.vsapi = vsapi;
+    lw_log_handler_t* lhp = lwlibav_audio_get_log_handler(hp->adhp);
+    lhp->priv = &vsbh;
+    lhp->show_log = set_error;
+
+    size_t buffer_size = (size_t)sample_count * hp->aohp->output_block_align;
+    uint8_t* buffer = (uint8_t*)av_malloc(buffer_size);
+    if (!buffer) {
+        vsapi->setFilterError("lsmas: failed to allocate an audio buffer.", frame_ctx);
+        return NULL;
+    }
+    memset(buffer, hp->aohp->output_bits_per_sample == 8 ? 0x80 : 0, buffer_size);
+    if (render_audio(buffer, start, sample_count, hp) < 0 || hp->adhp->error) {
+        av_free(buffer);
+        vsapi->setFilterError("lsmas: failed to output an audio frame.", frame_ctx);
+        return NULL;
+    }
+    VSFrame* frame = vs_interleaved_audio_frame(hp->aohp, buffer, sample_count, core, vsapi);
+    av_free(buffer);
+    if (!frame)
+        vsapi->setFilterError("lsmas: failed to create an audio frame.", frame_ctx);
+    return frame;
+}
+
+static void VS_CC audio_free(void* instance_data, VSCore* core, const VSAPI* vsapi)
+{
+    free_handler((lwlibav_audio_handler_t**)&instance_data);
+}
+
+static void set_av_log_level(int64_t level)
+{
+    static const int levels[] = { AV_LOG_QUIET, AV_LOG_PANIC, AV_LOG_FATAL, AV_LOG_ERROR, AV_LOG_WARNING, AV_LOG_INFO, AV_LOG_VERBOSE,
+        AV_LOG_DEBUG, AV_LOG_TRACE };
+    av_log_set_level(level <= 0 ? levels[0] : levels[MIN(level, 8)]);
+}
+
+void VS_CC vs_lwlibavaudiosource_create(const VSMap* in, VSMap* out, void* user_data, VSCore* core, const VSAPI* vsapi)
+{
+    const char* source = vsapi->mapGetData(in, "source", 0, NULL);
+    int64_t stream_index;
+    int64_t cache;
+    int64_t av_sync;
+    int64_t rate;
+    int64_t ff_loglevel;
+    int64_t indexing_progress;
+    int64_t fill_agaps;
+    const char* cache_file;
+    const char* layout;
+    const char* decoder;
+    const char* cache_dir;
+    const char* ff_options;
+    int error;
+    double drc = vsapi->mapGetFloat(in, "drc_scale", 0, &error);
+    if (error)
+        drc = -1.0;
+    set_option_int64(&stream_index, -1, "stream_index", in, vsapi);
+    set_option_int64(&cache, 1, "cache", in, vsapi);
+    set_option_int64(&av_sync, 0, "av_sync", in, vsapi);
+    set_option_int64(&rate, 0, "rate", in, vsapi);
+    set_option_int64(&ff_loglevel, 0, "ff_loglevel", in, vsapi);
+    set_option_int64(&indexing_progress, 1, "indexingpr", in, vsapi);
+    set_option_int64(&fill_agaps, 0, "fill_agaps", in, vsapi);
+    set_option_string(&cache_file, NULL, "cachefile", in, vsapi);
+    set_option_string(&layout, NULL, "layout", in, vsapi);
+    set_option_string(&decoder, NULL, "decoder", in, vsapi);
+    set_option_string(&cache_dir, NULL, "cachedir", in, vsapi);
+    set_option_string(&ff_options, NULL, "ff_options", in, vsapi);
+    set_av_log_level(ff_loglevel);
+
+    lwlibav_audio_handler_t* hp = alloc_handler();
+    if (!hp) {
+        vsapi->mapSetError(out, "lsmas: failed to allocate the LWLibav audio handler.");
+        return;
+    }
+    set_preferred_decoder_names_on_buf(hp->preferred_decoder_names_buf, decoder);
+    lwlibav_audio_set_preferred_decoder_names(hp->adhp, tokenize_preferred_decoder_names(hp->preferred_decoder_names_buf));
+    lwlibav_audio_set_drc(hp->adhp, drc);
+    lwlibav_audio_set_decoder_options(hp->adhp, ff_options);
+    hp->aohp->fill_audio_gaps = (int)fill_agaps;
+
+    vs_basic_handler_t vsbh = { out, NULL, vsapi };
+    lw_log_handler_t lh = { 0 };
+    lh.name = "LWLibavAudioSource";
+    lh.level = LW_LOG_FATAL;
+    lh.priv = &vsbh;
+    lh.show_log = set_error;
+    lwlibav_audio_set_log_handler(hp->adhp, &lh);
+
+    lwlibav_option_t opt;
+    memset(&opt, 0, sizeof(opt));
+    opt.file_path = source;
+    opt.cache_dir = cache_dir;
+    opt.av_sync = av_sync != 0;
+    opt.no_create_index = !cache;
+    opt.index_file_path = cache_file;
+    opt.force_video = 0;
+    opt.force_video_index = -1;
+    opt.force_audio = stream_index >= 0;
+    opt.force_audio_index = stream_index >= 0 ? (int)stream_index : -1;
+
+    progress_indicator_t indicator;
+    memset(&indicator, 0, sizeof(indicator));
+    if (indexing_progress) {
+        indicator.update = update_indicator;
+        indicator.close = close_indicator;
+    }
+    if (lwlibav_construct_index(&hp->lwh, hp->vdhp, hp->vohp, hp->adhp, hp->aohp, &lh, &opt, &indicator, NULL) < 0) {
+        free_handler(&hp);
+        set_error_on_init(out, vsapi, "lsmas: failed to construct an index for %s.", source);
+        return;
+    }
+    lwlibav_video_free_decode_handler_ptr(&hp->vdhp);
+    lwlibav_video_free_output_handler_ptr(&hp->vohp);
+    if (lwlibav_audio_get_desired_track(hp->lwh.file_path, hp->adhp, hp->lwh.threads) < 0
+        || lwlibav_import_av_index_entry((lwlibav_decode_handler_t*)hp->adhp) < 0) {
+        free_handler(&hp);
+        vsapi->mapSetError(out, "lsmas: failed to initialize the requested audio track.");
+        return;
+    }
+    AVCodecContext* ctx = lwlibav_audio_get_codec_context(hp->adhp);
+    if (vs_setup_audio_rendering(hp->aohp, ctx, layout, (int)MAX(rate, 0), &hp->ai, core, vsapi) < 0) {
+        free_handler(&hp);
+        vsapi->mapSetError(out, "lsmas: failed to configure audio output.");
+        return;
+    }
+    hp->ai.numSamples = lwlibav_audio_count_overall_pcm_samples(hp->adhp, hp->aohp->output_sample_rate);
+    if (hp->ai.numSamples <= 0) {
+        free_handler(&hp);
+        vsapi->mapSetError(out, "lsmas: no valid audio frame.");
+        return;
+    }
+    if (hp->lwh.av_gap && hp->aohp->output_sample_rate != ctx->sample_rate)
+        hp->lwh.av_gap = (hp->lwh.av_gap * hp->aohp->output_sample_rate - 1) / ctx->sample_rate + 1;
+    hp->ai.numSamples += hp->lwh.av_gap;
+    hp->ai.numFrames = (int)((hp->ai.numSamples + VS_AUDIO_FRAME_SAMPLES - 1) / VS_AUDIO_FRAME_SAMPLES);
+    if (make_gap_list(hp, out, vsapi) < 0) {
+        free_handler(&hp);
+        return;
+    }
+    lwlibav_audio_force_seek(hp->adhp);
+
+    VSNode* node = vsapi->createAudioFilter2("LWLibavAudioSource", &hp->ai, audio_get_frame, audio_free, fmUnordered, NULL, 0, hp, core);
+    if (!node) {
+        free_handler(&hp);
+        vsapi->mapSetError(out, "lsmas: failed to create the LWLibav audio node.");
+        return;
+    }
+    vsapi->setLinearFilter(node);
+    vsapi->mapConsumeNode(out, "audio", node, maAppend);
+}

--- a/VapourSynth/lwlibav_audio_source.c
+++ b/VapourSynth/lwlibav_audio_source.c
@@ -90,7 +90,7 @@ static int make_gap_list(lwlibav_audio_handler_t* hp, VSMap* out, const VSAPI* v
         return 0;
     const audio_frame_info_t* info = adhp->frame_list;
     int gap_count = 0;
-    for (uint32_t i = 1; i < adhp->frame_count; i++) {
+    for (uint32_t i = 1; i <= adhp->frame_count; i++) {
         if (info[i].file_offset == -1)
             gap_count++;
     }
@@ -106,7 +106,7 @@ static int make_gap_list(lwlibav_audio_handler_t* hp, VSMap* out, const VSAPI* v
     uint64_t sequence_sample_count = 0;
     uint64_t prior_sequence_sample_count = 0;
     int gap_index = 0;
-    for (uint32_t i = 1; i < adhp->frame_count; i++) {
+    for (uint32_t i = 1; i <= adhp->frame_count; i++) {
         if ((current_sample_rate != info[i].sample_rate && info[i].sample_rate > 0) || current_frame_length != info[i].length) {
             prior_sequence_sample_count += av_rescale_rnd(
                 sequence_sample_count, hp->aohp->output_sample_rate, current_sample_rate, AV_ROUND_UP);
@@ -338,7 +338,8 @@ void VS_CC vs_lwlibavaudiosource_create(const VSMap* in, VSMap* out, void* user_
         return;
     }
     if (hp->lwh.av_gap && hp->aohp->output_sample_rate != ctx->sample_rate)
-        hp->lwh.av_gap = (hp->lwh.av_gap * hp->aohp->output_sample_rate - 1) / ctx->sample_rate + 1;
+        hp->lwh.av_gap = av_rescale_rnd(
+            hp->lwh.av_gap, hp->aohp->output_sample_rate, ctx->sample_rate, AV_ROUND_UP);
     hp->ai.numSamples += hp->lwh.av_gap;
     hp->ai.numFrames = (int)((hp->ai.numSamples + VS_AUDIO_FRAME_SAMPLES - 1) / VS_AUDIO_FRAME_SAMPLES);
     if (make_gap_list(hp, out, vsapi) < 0) {

--- a/VapourSynth/lwlibav_audio_source.c
+++ b/VapourSynth/lwlibav_audio_source.c
@@ -125,7 +125,7 @@ static int make_gap_list(lwlibav_audio_handler_t* hp, VSMap* out, const VSAPI* v
                 set_error_on_init(out, vsapi, "lsmas: the resampled audio gap is too large.");
                 return -1;
             }
-            adhp->gap_list[gap_index].pts_in_samples = gap_start;
+            adhp->gap_list[gap_index].pts_in_samples = gap_start + hp->lwh.av_gap;
             adhp->gap_list[gap_index].length = (int)gap_length;
             gap_index++;
         }
@@ -147,10 +147,10 @@ static int delay_audio(lwlibav_audio_handler_t* hp, int64_t* start, int64_t want
     return 1;
 }
 
-static int decode_audio_range(
-    uint8_t* buf, int64_t output_start, int64_t length, int64_t removed_gap_length, lwlibav_audio_handler_t* hp)
+static int decode_audio_range(uint8_t* buf, int64_t output_start, int64_t length, lwlibav_audio_handler_t* hp)
 {
-    int64_t source_start = output_start - removed_gap_length;
+    /* Synthetic gap frames are already part of the decoder's PCM timeline. */
+    int64_t source_start = output_start;
     if (!delay_audio(hp, &source_start, length))
         return 0;
     return lwlibav_audio_get_pcm_samples(hp->adhp, hp->aohp, buf, source_start, length) == (uint64_t)length ? 0 : -1;
@@ -161,35 +161,31 @@ static int render_audio(uint8_t* buf, int64_t start, int64_t wanted_length, lwli
     lwlibav_audio_decode_handler_t* adhp = hp->adhp;
     lwlibav_audio_output_handler_t* aohp = hp->aohp;
     if (!aohp->fill_audio_gaps || !adhp->gap_list)
-        return decode_audio_range(buf, start, wanted_length, 0, hp);
+        return decode_audio_range(buf, start, wanted_length, hp);
 
     int64_t end = start + wanted_length;
     int64_t cursor = start;
-    int64_t removed_gap_length = 0;
     for (int i = 0; i < adhp->gap_count; i++) {
-        int64_t gap_start = adhp->gap_list[i].pts_in_samples + hp->lwh.av_gap;
+        int64_t gap_start = adhp->gap_list[i].pts_in_samples;
         int64_t gap_length = adhp->gap_list[i].length;
         int64_t gap_end = gap_start + gap_length;
-        if (gap_end <= cursor) {
-            removed_gap_length += gap_length;
+        if (gap_end <= cursor)
             continue;
-        }
         if (gap_start >= end)
             break;
         if (gap_start > cursor) {
             int64_t decode_length = MIN(gap_start, end) - cursor;
             uint8_t* decode_buf = buf + (cursor - start) * aohp->output_block_align;
-            if (decode_audio_range(decode_buf, cursor, decode_length, removed_gap_length, hp) < 0)
+            if (decode_audio_range(decode_buf, cursor, decode_length, hp) < 0)
                 return -1;
         }
         cursor = MAX(cursor, gap_end);
-        removed_gap_length += gap_length;
         if (cursor >= end)
             return 0;
     }
     if (cursor < end) {
         uint8_t* decode_buf = buf + (cursor - start) * aohp->output_block_align;
-        if (decode_audio_range(decode_buf, cursor, end - cursor, removed_gap_length, hp) < 0)
+        if (decode_audio_range(decode_buf, cursor, end - cursor, hp) < 0)
             return -1;
     }
     return 0;

--- a/VapourSynth/lwlibav_source.c
+++ b/VapourSynth/lwlibav_source.c
@@ -31,41 +31,6 @@
 #include <libswscale/swscale.h> /* Colorspace converter */
 
 #include "../common/audio_output.h"
-#ifndef _MSC_VER
-/* Dummy definitions.
- * Audio resampler/buffer is NOT used at all in this filter. */
-typedef void AVAudioResampleContext;
-typedef void audio_samples_t;
-int flush_resampler_buffers(AVAudioResampleContext* avr)
-{
-    return 0;
-}
-int update_resampler_configuration(AVAudioResampleContext* avr, uint64_t out_channel_layout, int out_sample_rate,
-    enum AVSampleFormat out_sample_fmt, uint64_t in_channel_layout, int in_sample_rate, enum AVSampleFormat in_sample_fmt,
-    int* input_planes, int* input_block_align)
-{
-    return 0;
-}
-int resample_audio(AVAudioResampleContext* avr, audio_samples_t* out, audio_samples_t* in)
-{
-    return 0;
-}
-uint64_t output_pcm_samples_from_buffer(
-    lw_audio_output_handler_t* aohp, AVFrame* frame_buffer, uint8_t** output_buffer, enum audio_output_flag* output_flags)
-{
-    return 0;
-}
-
-uint64_t output_pcm_samples_from_packet(lw_audio_output_handler_t* aohp, AVCodecContext* ctx, AVPacket* pkt, AVFrame* frame_buffer,
-    uint8_t** output_buffer, enum audio_output_flag* output_flags)
-{
-    return 0;
-}
-
-void lw_cleanup_audio_output_handler(lw_audio_output_handler_t* aohp)
-{
-}
-#endif
 
 #include "lsmashsource.h"
 #include "video_output.h"

--- a/VapourSynth/meson.build
+++ b/VapourSynth/meson.build
@@ -17,16 +17,24 @@ version_h = declare_dependency(
 add_project_arguments('-DXXH_INLINE_ALL', '-D_FILE_OFFSET_BITS=64', '-DDEFAULT_CACHEDIR=' + get_option('cachedir'), language: 'c')
 
 sources = [
+  'audio_output.c',
+  'audio_output.h',
+  'libavsmash_audio_source.c',
   'libavsmash_source.c',
   'lsmashsource.c',
   'lsmashsource.h',
+  'lwlibav_audio_source.c',
   'lwlibav_source.c',
   'video_output.c',
   'video_output.h',
+  '../common/audio_output.c',
+  '../common/audio_output.h',
   '../common/decode.c',
   '../common/decode.h',
   '../common/libavsmash.c',
   '../common/libavsmash.h',
+  '../common/libavsmash_audio.c',
+  '../common/libavsmash_audio.h',
   '../common/libavsmash_video.c',
   '../common/libavsmash_video.h',
   '../common/lwindex.c',
@@ -44,6 +52,8 @@ sources = [
   '../common/lwlibav_video.h',
   '../common/osdep.c',
   '../common/osdep.h',
+  '../common/resample.c',
+  '../common/resample.h',
   '../common/utils.c',
   '../common/utils.h',
   '../common/video_output.c',
@@ -58,6 +68,7 @@ deps = [
   dependency('libavcodec', version: '>=58.91.0'),
   dependency('libavformat', version: '>=58.45.0'),
   dependency('libavutil', version: '>=56.51.0'),
+  dependency('libswresample', version: '>=3.7.0'),
   dependency('libswscale', version: '>=5.7.0'),
   version_h
 ]

--- a/common/lwlibav_audio.c
+++ b/common/lwlibav_audio.c
@@ -222,12 +222,20 @@ static int find_start_audio_frame(
     if (*start_offset && current_sample_rate != output_sample_rate)
         *start_offset = (*start_offset * current_sample_rate - 1) / output_sample_rate + 1;
     if (frame_number > 1) {
-        /* Add pre-roll samples if needed.
-         * The condition is irresponsible. Patches welcome. */
+        /* Add one physical pre-roll frame for lossy audio.
+         * Synthetic gap entries have no packet and must not be used as pre-roll. */
         enum AVCodecID codec_id = adhp->exh.entries[frame_list[frame_number].extradata_index].codec_id;
         const AVCodecDescriptor* desc = avcodec_descriptor_get(codec_id);
-        if ((desc->props & AV_CODEC_PROP_LOSSY) && frame_list[frame_number].extradata_index == frame_list[frame_number - 1].extradata_index)
-            *start_offset += (uint64_t)frame_list[--frame_number].length;
+        if (desc->props & AV_CODEC_PROP_LOSSY) {
+            uint32_t pre_roll_frame = frame_number - 1;
+            while (pre_roll_frame > 0 && frame_list[pre_roll_frame].file_offset == -1)
+                --pre_roll_frame;
+            if (pre_roll_frame > 0
+                && frame_list[frame_number].extradata_index == frame_list[pre_roll_frame].extradata_index) {
+                *start_offset += (uint64_t)frame_list[pre_roll_frame].length;
+                frame_number = pre_roll_frame;
+            }
+        }
     }
     return frame_number;
 }

--- a/common/lwlibav_audio.h
+++ b/common/lwlibav_audio.h
@@ -62,6 +62,8 @@ void lwlibav_audio_set_drc(lwlibav_audio_decode_handler_t* adhp, const double dr
 
 void lwlibav_audio_set_decoder_options(lwlibav_audio_decode_handler_t* adhp, const char* ff_options);
 
+void lwlibav_audio_set_log_handler(lwlibav_audio_decode_handler_t* adhp, lw_log_handler_t* lh);
+
 /*****************************************************************************
  * Getters
  *****************************************************************************/


### PR DESCRIPTION
This code is a direct translation by LLM from AviSynth interface to VapourSynth interface. As integration testing validates, the result produced by both platform are byte-for-byte identical.